### PR TITLE
Change greedy search to lazy search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cookiemonsterteam/cookiemonsterframework",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cookiemonsterteam/cookiemonsterframework",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@eastdesire/jscolor": "^2.4.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cookiemonsterteam/cookiemonsterframework",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A package with functions used in the Cookie Monste Mod Framework",
   "keywords": [
     "mod",

--- a/src/savingAndLoading/saveFramework.js
+++ b/src/savingAndLoading/saveFramework.js
@@ -9,7 +9,7 @@ export default function saveFramework() {
     const cookieClickerSaveString = b64_to_utf8(
       unescape(localStorage.getItem('CookieClickerGame')).split('!END!')[0],
     );
-    const pattern = new RegExp(`${modName}.*(;|$)`);
+    const pattern = new RegExp(`${modName}.*?(;|$)`);
     const modSave = cookieClickerSaveString.match(pattern);
     if (modSave !== null) {
       const newSaveString = cookieClickerSaveString.replace(


### PR DESCRIPTION
A greedy replacement will unintentionally override the save data for other mods. This simple fix will resolve that issue.

Fixes #19 